### PR TITLE
chore: switched order of cdns

### DIFF
--- a/zones/purplebubble.org.yaml
+++ b/zones/purplebubble.org.yaml
@@ -35,11 +35,11 @@ _github-challenge-thepurplebubble-org:
   value: c90fd1f212
 cdn:
   records:
-    - type: A
-      value: 65.19.76.238
-      ttl: 300
     - type: CNAME
       value: chipper-druid-7fcb90.netlify.app
+      ttl: 300
+    - type: A
+      value: 65.19.76.238
       ttl: 300
 ns1:
   type: A


### PR DESCRIPTION
# chore: switched order of CDNs
## Description:
Switched the order of the CDNs temporarily so that Netlify is primary